### PR TITLE
chore: add automated star history chart

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -1,0 +1,22 @@
+name: Update Star History
+
+on:
+  schedule:
+    # Every Monday at 04:30 UTC (12:30 Asia/Singapore)
+    - cron: "30 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-star-history:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Generate star history
+        uses: xpzouying/star-history@v1
+        with:
+          branch: star-history
+          commit-message: "chore: update star history chart"

--- a/README.md
+++ b/README.md
@@ -123,3 +123,16 @@ absolute path of `run_journal.exe`.
 See [architecture](docs/architecture.md), [0.1 migration](docs/migration-0.2.md),
 and [real NX validation](docs/real-nx-validation.md) for implementation and
 release gates.
+
+## Star History
+
+<picture>
+  <source
+    media="(prefers-color-scheme: dark)"
+    srcset="https://raw.githubusercontent.com/DreamEnding/NX_MCP/star-history/assets/star-history-dark.svg"
+  />
+  <img
+    alt="Star History Chart"
+    src="https://raw.githubusercontent.com/DreamEnding/NX_MCP/star-history/assets/star-history.svg"
+  />
+</picture>


### PR DESCRIPTION
Adds a weekly and manually dispatchable star-history workflow that publishes light and dark SVG charts to a dedicated force-pushed data branch. Updates the README to load both theme variants from that branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Star History section to the README.
  * Added light- and dark-mode chart displays for improved readability.

* **Chores**
  * Added an automated weekly update for the repository’s star-history chart.
  * Added support for manually triggering chart updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->