### PR TITLE
fix: create star history output directory

### DIFF
--- a/.github/workflows/star-history.yml
+++ b/.github/workflows/star-history.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+      - name: Create chart output directory
+        run: mkdir -p assets
       - name: Generate star history
         uses: xpzouying/star-history@v1
         with:


### PR DESCRIPTION
The first manual run fetched all stargazers but failed because the upstream action does not create the parent directory for its default asset paths. Create the assets directory before invoking the action.